### PR TITLE
added HttpWarning to Observer

### DIFF
--- a/errtrack/errortracking.go
+++ b/errtrack/errortracking.go
@@ -3,9 +3,10 @@ package errtrack
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/JoinVerse/obs/errtrack/gcp"
 	"github.com/JoinVerse/obs/errtrack/sentry"
-	"net/http"
 )
 
 // SentryConfig handles Sentry exporter configuration.
@@ -31,6 +32,7 @@ type ErrorTracker struct {
 type errorExporter interface {
 	CaptureError(err error, tags map[string]string)
 	CaptureHttpError(err error, r *http.Request, tags map[string]string)
+	CaptureHttpWarning(err error, r *http.Request, tags map[string]string)
 	Close()
 }
 
@@ -76,6 +78,13 @@ func (e *ErrorTracker) CaptureError(err error, tags map[string]string) {
 func (e *ErrorTracker) CaptureHttpError(err error, r *http.Request, tags map[string]string) {
 	for _, e := range e.errorExporters {
 		e.CaptureHttpError(err, r, tags)
+	}
+}
+
+// CaptureHttpWarning sends error to all other error trackers.
+func (e *ErrorTracker) CaptureHttpWarning(err error, r *http.Request, tags map[string]string) {
+	for _, e := range e.errorExporters {
+		e.CaptureHttpWarning(err, r, tags)
 	}
 }
 

--- a/errtrack/gcp/exporter.go
+++ b/errtrack/gcp/exporter.go
@@ -58,6 +58,11 @@ func (e *Exporter) CaptureHttpError(err error, r *http.Request, tags map[string]
 	e.errorClient.Flush()
 }
 
+// CaptureHttpWarning send error to Google Cloud's Stack Driver.
+func (e *Exporter) CaptureHttpWarning(err error, r *http.Request, tags map[string]string) {
+	e.CaptureHttpError(err, r, tags)
+}
+
 func (e *Exporter) getUser(r *http.Request) string {
 	if e.getUserFn != nil {
 		return e.getUserFn(r)

--- a/errtrack/noop/exporter.go
+++ b/errtrack/noop/exporter.go
@@ -16,5 +16,8 @@ func (*Exporter) CaptureError(err error, tags map[string]string) {}
 // CaptureHttpError send error to nowhere.
 func (*Exporter) CaptureHttpError(err error, r http.Request, tags map[string]string) {}
 
+// CaptureHttpWarning send warning to nowhere.
+func (*Exporter) CaptureHttpWarning(err error, r http.Request, tags map[string]string) {}
+
 // Close does nothing.
 func (*Exporter) Close() {}

--- a/errtrack/sentry/exporter.go
+++ b/errtrack/sentry/exporter.go
@@ -53,6 +53,18 @@ func (e *Exporter) CaptureHttpError(err error, r *http.Request, tags map[string]
 	})
 }
 
+// CaptureHttpWarning send warning to Sentry.
+func (e *Exporter) CaptureHttpWarning(err error, r *http.Request, tags map[string]string) {
+	user := e.getUser(r)
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetLevel(sentry.LevelWarning)
+		scope.SetRequest(r)
+		scope.SetTags(tags)
+		scope.SetUser(sentry.User(user))
+		sentry.CaptureException(err)
+	})
+}
+
 func (e *Exporter) getUser(r *http.Request) User {
 	if e.getUserFn != nil {
 		return e.getUserFn(r)

--- a/observability.go
+++ b/observability.go
@@ -1,9 +1,10 @@
 package obs
 
 import (
+	"net/http"
+
 	"cloud.google.com/go/profiler"
 	"github.com/JoinVerse/obs/errtrack"
-	"net/http"
 )
 
 type Config struct {
@@ -77,6 +78,17 @@ func (o *Observer) HttpError(r *http.Request, err error) {
 // HTTPError logs an error message to Stderr and send the error among the tags, to configured trackers.
 func (o *Observer) HttpErrorTags(r *http.Request, tags map[string]string, err error) {
 	o.errTrack.CaptureHttpError(err, r, tags)
+	o.log.Error("", err)
+}
+
+// HTTPWarning logs an error message to Stderr and send the error to configured trackers.
+func (o *Observer) HttpWarning(r *http.Request, err error) {
+	o.HttpWarningTags(r, nil, err)
+}
+
+// HTTPWarning logs an error message to Stderr and send the error among the tags, to configured trackers.
+func (o *Observer) HttpWarningTags(r *http.Request, tags map[string]string, err error) {
+	o.errTrack.CaptureHttpWarning(err, r, tags)
 	o.log.Error("", err)
 }
 


### PR DESCRIPTION
We need to send to sentry events as warnings. 

We have added a new func HttpWarning at observer struct. 