### PR TITLE
Set time format in nano seconds

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -18,6 +18,7 @@ import (
 var logger *zerolog.Logger
 
 func init() {
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 	host, _ := os.Hostname()
 	l := zerolog.New(os.Stdout).With().Timestamp().Str("host", host).Logger()
 	logger = &l


### PR DESCRIPTION
Checking logs if two services logs in the same second, we can not know which log was produced first.