### PR TITLE
Adding response body in log

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -146,7 +146,11 @@ func ResponseBodyHandler(fieldKey string) func(next http.Handler) http.Handler {
 				next.ServeHTTP(c, r)
 
 				// Copy headers from response recorder to actual response writer
-				for k, v := range c.HeaderMap {
+				resp := c.Result()
+				if resp == nil {
+					return
+				}
+				for k, v := range resp.Header {
 					w.Header()[k] = v
 				}
 				w.WriteHeader(c.Code)

--- a/hlog/hlog_test.go
+++ b/hlog/hlog_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func decodeIfBinary(out *bytes.Buffer) (string, error) {
@@ -135,4 +136,33 @@ func TestHTTPRequestLogFormat(t *testing.T) {
 
 	actualLog.HTTPRequestLog["latency"] = "0.000000s" // Just ignore the latency value
 	assert.Equal(t, expectedHTTPRequestJSON, actualLog.HTTPRequestLog, "Unexpected HttpRequest Log Format")
+}
+
+func TestResponseBodyHandler(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := make(map[string]string)
+		resp["foo"] = "bar"
+
+		jsonResp, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonResp)
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	out := &bytes.Buffer{}
+	l := NewWithWriter(out)
+	h := l.Handler(handler)
+	h.ServeHTTP(w, r)
+
+	actualLog := struct {
+		RequestBody map[string]interface{} `json:"responseBody"`
+	}{}
+
+	require.NoError(t, json.Unmarshal(out.Bytes(), &actualLog))
+
+	assert.Len(t, actualLog.RequestBody, 1)
+	assert.Equal(t, "bar", actualLog.RequestBody["foo"])
 }


### PR DESCRIPTION
Was not sure how to approach this, ended up with a responseRecorder to later write the headers and body into the responseWriter. This is because I can't read the response from the responseWriter.

Also, added some example urls to test. Screenshots below that show the response both in localhost and in the log:

### OK
![image](https://user-images.githubusercontent.com/36658188/182164829-018462cb-2e01-45f2-8267-d1edd9e91693.png)
![image](https://user-images.githubusercontent.com/36658188/182165155-068bba31-4ec6-4644-a2ec-0f2328869386.png)

### Error
![image](https://user-images.githubusercontent.com/36658188/182165261-738fad9f-ce03-4041-91a7-399772113568.png)
![image](https://user-images.githubusercontent.com/36658188/182165400-dc04a7f2-ca8e-4a5b-8961-0364394a134f.png)

### With JSON response body
![image](https://user-images.githubusercontent.com/36658188/182165488-1bc6c0d6-da92-4dcc-af30-3f41dc8cfe9e.png)
![image](https://user-images.githubusercontent.com/36658188/182165649-7d5ca128-8f91-437c-a4dc-b0111666fe20.png)

### With no response body
![image](https://user-images.githubusercontent.com/36658188/182165766-404dccb5-d4e9-4281-9397-7e559ff4e3c0.png)
![image](https://user-images.githubusercontent.com/36658188/182165906-fd85c903-a763-4a42-8f5d-90504d16fbc4.png)
